### PR TITLE
Deleted Underline

### DIFF
--- a/foundation/index.html
+++ b/foundation/index.html
@@ -390,7 +390,7 @@ var lowerie = false;
               <a class="youtube" href="https://www.youtube.com/channel/UCbQ9vGfezru1YRI1zDCtTGg" target="_blank"><em class="fa fa-youtube-play"></em></a>
               <a class="zoom-social_icons-list__link" href="https://chat.cardanohub.org/home" target="_blank" style="background: #fff;"><em class="fa fa-rocket" style="color:#c1272d;"></em></a>
               <a class="zoom-social_icons-list__link" href="https://forum.cardanohub.org" target="_blank" style="background: #fff;">
-                <span class="zoom-social_icons-list-span dashicons dashicons-format-status" data-hover-rule="color" data-hover-color="#da7226" style="color : #da7226;font-size: 18px;padding:2px; vertical-align: middle;" data-old-color="rgb(255, 249, 174)"></span>
+                <span class="zoom-social_icons-list-span dashicons dashicons-format-status"></span>
               </a>
             </div>
             <p>


### PR DESCRIPTION
Under 'Join Our Community' on the foundation page, the only icon that had an underline was the Forum icon. I deleted it since it did not go with the regular style.